### PR TITLE
[feature] README.rst is too complex for README file, down graded to MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Gravity's Rainbow
+
+
+```
+
+	    10
+	   /  \        "Programs must be written for people to read,
+	  3    23       and only incidentally for machines to execute."
+	 / \   / \      - H. Abelson and G. Sussman
+	1     20 50
+
+```


### PR DESCRIPTION
- Renamed README.rst to README.md
- Changed the directives to MD
- Changed contents of README